### PR TITLE
Support a few more METAR types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,12 +374,12 @@ impl<'a> Metar<'a> {
                                     },
                                 };
                             } else if let Err(e) = r {
-                                return Err(MetarError::new(data, word_idx.1 + e.0, e.1,
-                                    state, ParserError::CloudVisibility(e.2)));
+                                state = ParseState::CloudVisOrTemps;
+                                //return Err(MetarError::new(data, word_idx.1 + e.0, e.1,
+                               //     state, ParserError::CloudVisibility(e.2)));
                             }
 
                             state = ParseState::CloudVisOrTemps;
-                            continue;
                         } else {
                             return Err(MetarError::new(data, word_idx.1 + e.0, e.1,
                                 state, ParserError::WindVarying(e.2)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,9 @@ impl<'a> Metar<'a> {
 
         let mut state = ParseState::Station;
         for word in data.split_whitespace() {
+            if !word.is_ascii() {
+                continue;
+            }
 
             match state {
                 ParseState::Station => {
@@ -393,24 +396,5 @@ impl<'a> Metar<'a> {
         }
 
         Ok(metar)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_find_words() {
-        let r = find_words("The quick brown fox.");
-        assert_eq!(
-            r,
-            [
-                ("The", 0, 3),
-                ("quick", 4, 5),
-                ("brown", 10, 5),
-                ("fox.", 16, 4)
-            ]
-        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,8 @@ pub struct Metar<'a> {
     pub dewpoint: Data<i32>,
     /// The current air pressure
     pub pressure: Data<Pressure>,
-    /// Any remarks made about the METAR
-    pub remarks: Option<&'a str>,
+    /// The current air pressure converted to sea level
+    pub sea_level_pressure: Data<Pressure>,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -284,7 +284,7 @@ impl<'a> Metar<'a> {
             temperature: Unknown,
             dewpoint: Unknown,
             pressure: Unknown,
-            remarks: None,
+            sea_level_pressure: Unknown,
         };
 
         let mut state = ParseState::Station;
@@ -414,8 +414,10 @@ impl<'a> Metar<'a> {
                     }
                 }
                 ParseState::RemarksOrEnd => {
-                    metar.remarks = Some(&data[word_idx.1..]);
-                    break;
+                    let r = parsers::parse_sea_level_pressure(word);
+                    if let Ok(data) = r {
+                        metar.sea_level_pressure = data;
+                    }
                 }
             }
         }

--- a/src/parsers/errors.rs
+++ b/src/parsers/errors.rs
@@ -5,8 +5,8 @@ use std::fmt;
 pub enum StationError {
     /// The station ID is not the correct length
     IncorrectLength,
-    /// A character was found to be not alphabetic
-    NonAlphabeticCharacter,
+    /// A character was found to be not alphanumeric
+    NonAlphanumericCharacter,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -83,7 +83,7 @@ impl fmt::Display for StationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::IncorrectLength => write!(f, "The station ID was not the correct length."),
-            Self::NonAlphabeticCharacter => write!(f, "Found a non-alphabetic character."),
+            Self::NonAlphanumericCharacter => write!(f, "Found a non-alphanumeric character."),
         }
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -337,10 +337,15 @@ pub fn parse_cloud_visibility_info<'a>(
                 unit: DistanceUnit::StatuteMiles,
             })));
         } else {
-            return Ok(CloudVisibilityInfo::Visibility(Known(Visibility {
-                visibility: s.parse().unwrap(),
-                unit: DistanceUnit::StatuteMiles,
-            })));
+            let val = s.parse::<f32>();
+            if let Ok(val) = val {
+                return Ok(CloudVisibilityInfo::Visibility(Known(Visibility {
+                    visibility: val,
+                    unit: DistanceUnit::StatuteMiles,
+                })));
+            } else {
+                return Ok(CloudVisibilityInfo::Visibility(Unknown));
+            }
         }
     }
 
@@ -511,6 +516,9 @@ pub fn parse_temperatures<'a>(
 
     let mut i = 0;
     if chs[i] == 'M' {
+        if s.len() <= (i + 2) {
+            return Err((i, 1, TemperatureError::TemperatureNotValid));
+        }
         if !chs[i + 1].is_digit(10) {
             return Err((i + 1, 1, TemperatureError::TemperatureNotValid));
         }
@@ -520,6 +528,9 @@ pub fn parse_temperatures<'a>(
         temp = -1 * s[i + 1..i + 3].parse::<i32>().unwrap();
         i += 4;
     } else {
+        if s.len() <= (i + 1) {
+            return Err((i, 1, TemperatureError::TemperatureNotValid));
+        }
         if !chs[i].is_digit(10) {
             return Err((i, 1, TemperatureError::TemperatureNotValid));
         }
@@ -531,6 +542,9 @@ pub fn parse_temperatures<'a>(
     }
 
     if chs[i] == 'M' {
+        if s.len() <= (i + 2) {
+            return Err((i, 1, TemperatureError::DewpointNotValid));
+        }
         if !chs[i + 1].is_digit(10) {
             return Err((i + 1, 1, TemperatureError::DewpointNotValid));
         }
@@ -539,6 +553,9 @@ pub fn parse_temperatures<'a>(
         }
         dewp = -1 * s[i + 1..i + 3].parse::<i32>().unwrap();
     } else {
+        if s.len() <= (i + 1) {
+            return Err((i, 1, TemperatureError::DewpointNotValid));
+        }
         if !chs[i].is_digit(10) {
             return Err((i, 1, TemperatureError::DewpointNotValid));
         }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -329,13 +329,18 @@ pub fn parse_cloud_visibility_info<'a>(
         } else if s.contains("/") {
             // Fractional visibilty
             let parts: Vec<_> = s.split("/").collect();
-            let numerator: u32 = parts[0].parse().unwrap();
-            let denominator: u32 = parts[1].parse().unwrap();
-            let fraction: f32 = numerator as f32 / denominator as f32;
-            return Ok(CloudVisibilityInfo::Visibility(Known(Visibility {
-                visibility: fraction,
-                unit: DistanceUnit::StatuteMiles,
-            })));
+	    let part0 = parts[0].parse::<f32>();
+            let part1 = parts[1].parse::<f32>();
+            if let (Ok(numerator), Ok(denominator)) = (part0, part1) {
+            	let fraction: f32 = numerator / denominator;
+            	return Ok(CloudVisibilityInfo::Visibility(Known(Visibility {
+                	visibility: fraction,
+                	unit: DistanceUnit::StatuteMiles,
+            	})));
+	    } else {
+		return Ok(CloudVisibilityInfo::Visibility(Unknown));
+
+	    }
         } else {
             let val = s.parse::<f32>();
             if let Ok(val) = val {

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -318,7 +318,7 @@ pub fn parse_cloud_visibility_info<'a>(
             return Ok(CloudVisibilityInfo::Visibility(Unknown));
         }
     }
-    if s.ends_with("SM") {
+    if s.len() > 2 && s.ends_with("SM") {
         let s = &s[0..s.len() - 2];
         if chs[0] == 'M' {
             // Used to report visibility less than 1/4th SM. Just convert it to 0 for now.

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -27,8 +27,8 @@ pub fn parse_station<'a>(s: &'a str) -> ParserResult<&'a str, StationError> {
     let chs: Vec<_> = s.chars().collect();
     for i in 0..chs.len() {
         let c = chs[i];
-        if !c.is_alphabetic() {
-            return Err((i, 1, StationError::NonAlphabeticCharacter));
+        if !c.is_alphanumeric() {
+            return Err((i, 1, StationError::NonAlphanumericCharacter));
         }
     }
     Ok(s)

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -591,3 +591,34 @@ pub fn parse_pressure<'a>(s: &'a str) -> ParserResult<Data<Pressure>, PressureEr
         return Err((0, 1, PressureError::UnitNotValid));
     }
 }
+
+pub fn parse_sea_level_pressure<'a>(s: &'a str) -> ParserResult<Data<Pressure>, PressureError> {
+    if s.len() < 6 {
+        return Err((1, s.len(), PressureError::UnitNotValid));
+    }
+
+    if s == "SLP///" {
+        return Ok(Unknown);
+    }
+
+    let chs: Vec<_> = s.chars().collect();
+
+    if chs[0] == 'S' && chs[1] == 'L' && chs[2] == 'P' {
+        if chs[3].is_digit(10) && chs[4].is_digit(10) && chs[5].is_digit(10) {
+            let mut pressure = s[3..6].parse().unwrap();
+            if pressure >= 550.0 {
+                pressure = pressure / 10.0 + 900.0;
+            } else {
+                pressure = pressure / 10.0 + 1000.0;
+            }
+            return Ok(Known(Pressure {
+                pressure,
+                unit: PressureUnit::Hectopascals,
+            }));
+        } else {
+            return Err((0, 1, PressureError::UnitNotValid));
+        }
+    } else {
+        return Err((0, 1, PressureError::UnitNotValid));
+    }
+}

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -372,6 +372,10 @@ pub fn parse_cloud_visibility_info<'a>(
         // Vicinity
         intensity = WeatherIntensity::InVicinity;
         i += 2;
+    } else if chs[0] == 'R' && chs[1] == 'E' {
+        // Recent
+        intensity = WeatherIntensity::Recent;
+        i += 2;
     } else {
         intensity = WeatherIntensity::Moderate;
     }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -321,7 +321,13 @@ pub fn parse_cloud_visibility_info<'a>(s: &'a str) -> ParserResult<CloudVisibili
     }
     if s.ends_with("SM") {
         let s = &s[0..s.len() - 2];
-        if s.contains("/") {
+        if chs[0] == 'M' {
+            // Used to report visibility less than 1/4th SM. Just convert it to 0 for now.
+            return Ok(CloudVisibilityInfo::Visibility(Known(Visibility {
+                visibility: 0.0,
+                unit: DistanceUnit::StatuteMiles,
+            })));
+        } else if s.contains("/") {
             // Fractional visibilty
             let parts: Vec<_> = s.split("/").collect();
             let numerator: u32 = parts[0].parse().unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -194,6 +194,8 @@ pub enum WeatherIntensity {
     Heavy,
     /// In the vicinity (VC)
     InVicinity,
+    /// Recent (RE)
+    Recent,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,7 @@ impl<T> Data<T> {
     pub fn unwrap(&self) -> &T {
         match self {
             Data::Known(v) => v,
-            Data::Unknown => panic!("cannot unwrap unknown data")
+            Data::Unknown => panic!("cannot unwrap unknown data"),
         }
     }
 
@@ -24,7 +24,7 @@ impl<T> Data<T> {
     pub fn unwrap_mut(&mut self) -> &mut T {
         match self {
             Data::Known(v) => v,
-            Data::Unknown => panic!("cannot unwrap unknown data")
+            Data::Unknown => panic!("cannot unwrap unknown data"),
         }
     }
 }

--- a/tests/metars.rs
+++ b/tests/metars.rs
@@ -1127,3 +1127,33 @@ fn test_metar_22() {
         })
     );
 }
+
+#[test]
+fn test_metar_23() {
+    let metar = "KGYY 312245Z 02014G26KT 1 SM R30/4500FT -SN OVC006 00/M01 A2999";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+    println!("{:#?}", r);
+    assert_eq!(r.station, "KGYY");
+    assert_eq!(r.time.date, 31);
+    assert_eq!(r.time.hour, 22);
+    assert_eq!(r.time.minute, 45);
+}
+
+#[test]
+fn test_metar_24() {
+    let metar = "KREO 311852Z AUTO 33biÃ<8f><8a>^U$L<9b>/M04 A3020 RMK AO1 SLP242 T00561039";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+    println!("{:#?}", r);
+    assert_eq!(r.station, "KREO");
+    assert_eq!(r.time.date, 31);
+    assert_eq!(r.time.hour, 18);
+    assert_eq!(r.time.minute, 52);
+}

--- a/tests/metars.rs
+++ b/tests/metars.rs
@@ -590,3 +590,97 @@ fn test_metar_17() {
     assert_eq!(r.dewpoint, Known(3));
     assert_eq!(r.pressure, Known(Pressure { pressure: 973.0, unit: Hectopascals }));
 }
+
+#[test]
+fn test_metar_18() {
+    let metar = "KC62 220155Z AUTO 28015G21KT 10SM 03/00 A2971 RMK AO2 T00360000";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+
+    assert_eq!(r.station, "KC62");
+    assert_eq!(r.time.date, 22);
+    assert_eq!(r.time.hour, 01);
+    assert_eq!(r.time.minute, 55);
+    assert_eq!(r.wind.dir, Known(WindDirection::Heading(280)));
+    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 15, unit: Knot }));
+    assert_eq!(r.wind.varying, None);
+    assert_eq!(r.wind.gusting, Some(WindSpeed { speed: 21, unit: Knot }));
+    assert_eq!(r.visibility, Known(Visibility { visibility: 10.0, unit: StatuteMiles }));
+    assert_eq!(r.clouds, Unknown);
+    assert_eq!(r.cloud_layers.len(), 0);
+    assert_eq!(r.vert_visibility, None);
+    assert_eq!(r.weather.len(), 0);
+    assert_eq!(r.temperature, Known(3));
+    assert_eq!(r.dewpoint, Known(0));
+    assert_eq!(r.pressure, Known(Pressure { pressure: 2971.0, unit: InchesMercury }));
+}
+
+#[test]
+fn test_metar_19() {
+    let metar = "PACZ 220150Z AUTO 11030G43KT M1/4SM +SN FG VV005 M04/M04 A2863 RMK AO2 SLP706";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+
+    assert_eq!(r.station, "PACZ");
+    assert_eq!(r.time.date, 22);
+    assert_eq!(r.time.hour, 01);
+    assert_eq!(r.time.minute, 50);
+    assert_eq!(r.wind.dir, Known(WindDirection::Heading(110)));
+    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 30, unit: Knot }));
+    assert_eq!(r.wind.varying, None);
+    assert_eq!(r.wind.gusting, Some(WindSpeed { speed: 43, unit: Knot }));
+    assert_eq!(r.visibility, Known(Visibility { visibility: 0.0, unit: StatuteMiles }));
+    assert_eq!(r.clouds, Unknown);
+    assert_eq!(r.cloud_layers.len(), 0);
+    assert_eq!(r.vert_visibility, Some(VertVisibility::Distance(5)));
+    assert_eq!(r.weather.len(), 2);
+    assert!(r.weather.contains(&Weather {
+        intensity: WeatherIntensity::Heavy,
+        conditions: vec![
+            WeatherCondition::Snow,
+        ],
+    }));
+    assert!(r.weather.contains(&Weather {
+        intensity: WeatherIntensity::Moderate,
+        conditions: vec![
+            WeatherCondition::Fog,
+        ],
+    }));
+    assert_eq!(r.temperature, Known(-4));
+    assert_eq!(r.dewpoint, Known(-4));
+    assert_eq!(r.pressure, Known(Pressure { pressure: 2863.0, unit: InchesMercury }));
+}
+
+/* #[test]
+fn test_metar_20() {
+    let metar = "CWPF 220145Z AUTO 25008KT 02/01 RMK AO1 SLP034 T00240009 51016";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+
+    assert_eq!(r.station, "CWPF");
+    assert_eq!(r.time.date, 22);
+    assert_eq!(r.time.hour, 01);
+    assert_eq!(r.time.minute, 45);
+    assert_eq!(r.wind.dir, Known(WindDirection::Heading(250)));
+    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 08, unit: Knot }));
+    assert_eq!(r.wind.varying, None);
+    assert_eq!(r.wind.gusting, None);
+    assert_eq!(r.visibility, Known(Visibility { visibility: 6000.0, unit: Metres }));
+    assert_eq!(r.clouds, Unknown);
+    assert_eq!(r.cloud_layers.len(), 0);
+    assert_eq!(r.vert_visibility, None);
+    assert_eq!(r.weather.len(), 0);
+    assert_eq!(r.temperature, Known(2));
+    assert_eq!(r.dewpoint, Known(1));
+    assert_eq!(r.pressure, Known(Pressure { pressure: 2971.0, unit: InchesMercury }));
+}
+*/

--- a/tests/metars.rs
+++ b/tests/metars.rs
@@ -1215,3 +1215,35 @@ fn test_metar_26() {
     assert_eq!(r.wind.gusting, None);
     assert_eq!(r.visibility, Unknown);
 }
+
+#[test]
+fn test_metar_27() {
+    let metar = "KMCO 071214Z 27016G21KT 2 1/2SMSM +TSRA BKN014 BKN022 OVC046CB 22/22 A2983 RMK TWR VIS 3 PRESFR FRQ LTGICCG OHD AND SW TS OHD AND SW MOV NE P0002 T02220217";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+    println!("{:#?}", r);
+    assert_eq!(r.station, "KMCO");
+    assert_eq!(r.time.date, 07);
+    assert_eq!(r.time.hour, 12);
+    assert_eq!(r.time.minute, 14);
+    assert_eq!(r.wind.dir, Known(WindDirection::Heading(270)));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 16,
+            unit: Knot
+        })
+    );
+    assert_eq!(r.wind.varying, None);
+    assert_eq!(
+        r.wind.gusting,
+        Some(WindSpeed {
+            speed: 21,
+            unit: Knot
+        })
+    );
+    assert_eq!(r.visibility, Unknown);
+}

--- a/tests/metars.rs
+++ b/tests/metars.rs
@@ -355,7 +355,7 @@ fn test_metar_7() {
         .cloud_layers
         .contains(&CloudLayer::Broken(CloudType::Normal, Some(10))));
     assert_eq!(r.vert_visibility, None);
-    assert_eq!(r.weather.len(), 1);
+    assert_eq!(r.weather.len(), 2);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Light,
         conditions: vec![WeatherCondition::Rain,],

--- a/tests/metars.rs
+++ b/tests/metars.rs
@@ -1,8 +1,8 @@
-use metar::*;
 use metar::Data::{Known, Unknown};
-use metar::SpeedUnit::*;
 use metar::DistanceUnit::*;
 use metar::PressureUnit::*;
+use metar::SpeedUnit::*;
+use metar::*;
 
 #[test]
 fn test_metar_1() {
@@ -18,25 +18,45 @@ fn test_metar_1() {
     assert_eq!(r.time.hour, 21);
     assert_eq!(r.time.minute, 20);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(190)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 15, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 15,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, Some((140, 220)));
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 6000.0, unit: Metres }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 6000.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 2);
-    assert!(r.cloud_layers.contains(&CloudLayer::Scattered(CloudType::Normal, Some(6))));
-    assert!(r.cloud_layers.contains(&CloudLayer::Broken(CloudType::Normal, Some(9))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Scattered(CloudType::Normal, Some(6))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(9))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 1);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Rain,
-        ],
+        conditions: vec![WeatherCondition::Rain,],
     }));
     assert_eq!(r.temperature, Known(16));
     assert_eq!(r.dewpoint, Known(14));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1006.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1006.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -54,7 +74,13 @@ fn test_metar_2() {
     assert_eq!(r.time.hour, 20);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(310)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 6, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 6,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, Some((270, 340)));
     assert_eq!(r.wind.gusting, None);
     assert!(r.visibility.unwrap().is_infinite());
@@ -64,7 +90,13 @@ fn test_metar_2() {
     assert_eq!(r.weather.len(), 0);
     assert_eq!(r.temperature, Known(13));
     assert_eq!(r.dewpoint, Known(7));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1017.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1017.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -82,31 +114,46 @@ fn test_metar_3() {
     assert_eq!(r.time.hour, 15);
     assert_eq!(r.time.minute, 20);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(190)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 13, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 13,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, Some((160, 220)));
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 3000.0, unit: Metres }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 3000.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 1);
-    assert!(r.cloud_layers.contains(&CloudLayer::Broken(CloudType::Normal, Some(6))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(6))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 2);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Light,
-        conditions: vec![
-            WeatherCondition::Rain,
-            WeatherCondition::Drizzle,
-        ],
+        conditions: vec![WeatherCondition::Rain, WeatherCondition::Drizzle,],
     }));
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Mist,
-        ],
+        conditions: vec![WeatherCondition::Mist,],
     }));
     assert_eq!(r.temperature, Known(15));
     assert_eq!(r.dewpoint, Known(14));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1012.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1012.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -124,31 +171,46 @@ fn test_metar_4() {
     assert_eq!(r.time.hour, 17);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(210)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 10, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 10,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 3500.0, unit: Metres }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 3500.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 1);
-    assert!(r.cloud_layers.contains(&CloudLayer::Broken(CloudType::Normal, Some(4))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(4))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 2);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Light,
-        conditions: vec![
-            WeatherCondition::Rain,
-            WeatherCondition::Drizzle,
-        ],
+        conditions: vec![WeatherCondition::Rain, WeatherCondition::Drizzle,],
     }));
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Mist,
-        ],
+        conditions: vec![WeatherCondition::Mist,],
     }));
     assert_eq!(r.temperature, Known(16));
     assert_eq!(r.dewpoint, Known(15));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1011.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1011.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -166,7 +228,13 @@ fn test_metar_5() {
     assert_eq!(r.time.hour, 06);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Variable));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 3, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 3,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
     assert!(r.visibility.unwrap().is_infinite());
@@ -176,7 +244,13 @@ fn test_metar_5() {
     assert_eq!(r.weather.len(), 0);
     assert_eq!(r.temperature, Known(12));
     assert_eq!(r.dewpoint, Known(10));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1009.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1009.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -194,25 +268,45 @@ fn test_metar_6() {
     assert_eq!(r.time.hour, 16);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(230)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 10, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 10,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 9999.0, unit: Metres }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 9999.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 2);
-    assert!(r.cloud_layers.contains(&CloudLayer::Few(CloudType::Normal, Some(18))));
-    assert!(r.cloud_layers.contains(&CloudLayer::Few(CloudType::ToweringCumulus, Some(25))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Few(CloudType::Normal, Some(18))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Few(CloudType::ToweringCumulus, Some(25))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 1);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::InVicinity,
-        conditions: vec![
-            WeatherCondition::Showers,
-        ],
+        conditions: vec![WeatherCondition::Showers,],
     }));
     assert_eq!(r.temperature, Known(15));
     assert_eq!(r.dewpoint, Known(11));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1006.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1006.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -230,26 +324,52 @@ fn test_metar_7() {
     assert_eq!(r.time.hour, 07);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(220)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 17, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 17,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, Some((190, 250)));
-    assert_eq!(r.wind.gusting, Some(WindSpeed { speed: 28, unit: Knot }));
-    assert_eq!(r.visibility, Known(Visibility { visibility: 6000.0, unit: Metres }));
+    assert_eq!(
+        r.wind.gusting,
+        Some(WindSpeed {
+            speed: 28,
+            unit: Knot
+        })
+    );
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 6000.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 2);
-    assert!(r.cloud_layers.contains(&CloudLayer::Few(CloudType::Normal, Some(7))));
-    assert!(r.cloud_layers.contains(&CloudLayer::Broken(CloudType::Normal, Some(10))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Few(CloudType::Normal, Some(7))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(10))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 1);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Light,
-        conditions: vec![
-            WeatherCondition::Rain,
-        ],
+        conditions: vec![WeatherCondition::Rain,],
     }));
     assert_eq!(r.temperature, Known(15));
     assert_eq!(r.dewpoint, Known(14));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1008.0, unit: Hectopascals }));
-    assert_eq!(r.remarks, Some("RERA"));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1008.0,
+            unit: Hectopascals
+        })
+    );
+    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -266,24 +386,39 @@ fn test_metar_8() {
     assert_eq!(r.time.hour, 19);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(060)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 01, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 01,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 9999.0, unit: Metres }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 9999.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::NoSignificantCloud));
     assert_eq!(r.cloud_layers.len(), 0);
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 1);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Shallow,
-            WeatherCondition::Fog,
-        ],
+        conditions: vec![WeatherCondition::Shallow, WeatherCondition::Fog,],
     }));
     assert_eq!(r.temperature, Known(09));
     assert_eq!(r.dewpoint, Known(08));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1010.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1010.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -301,23 +436,42 @@ fn test_metar_9() {
     assert_eq!(r.time.hour, 06);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(060)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 01, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 01,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 0500.0, unit: Metres }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 0500.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Unknown);
     assert_eq!(r.cloud_layers.len(), 0);
-    assert_eq!(r.vert_visibility, Some(VertVisibility::ReducedByUnknownAmount));
+    assert_eq!(
+        r.vert_visibility,
+        Some(VertVisibility::ReducedByUnknownAmount)
+    );
     assert_eq!(r.weather.len(), 1);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Fog,
-        ],
+        conditions: vec![WeatherCondition::Fog,],
     }));
     assert_eq!(r.temperature, Known(11));
     assert_eq!(r.dewpoint, Known(10));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1003.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1003.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -335,18 +489,36 @@ fn test_metar_10() {
     assert_eq!(r.time.hour, 13);
     assert_eq!(r.time.minute, 56);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(0)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 0, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 0,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 10.0, unit: StatuteMiles }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 10.0,
+            unit: StatuteMiles
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::SkyClear));
     assert_eq!(r.cloud_layers.len(), 0);
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 0);
     assert_eq!(r.temperature, Known(6));
     assert_eq!(r.dewpoint, Known(-3));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 3029.0, unit: InchesMercury }));
-    assert_eq!(r.remarks, Some("RMK AO2 SLP264 T00611028 $"));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 3029.0,
+            unit: InchesMercury
+        })
+    );
+    assert_eq!(r.remarks, Some("AO2 SLP264 T00611028 $"));
 }
 
 #[test]
@@ -363,26 +535,46 @@ fn test_metar_11() {
     assert_eq!(r.time.hour, 18);
     assert_eq!(r.time.minute, 53);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(260)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 7, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 7,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 5.0, unit: StatuteMiles }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 5.0,
+            unit: StatuteMiles
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 2);
-    assert!(r.cloud_layers.contains(&CloudLayer::Scattered(CloudType::Normal, Some(6))));
-    assert!(r.cloud_layers.contains(&CloudLayer::Broken(CloudType::Normal, Some(13))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Scattered(CloudType::Normal, Some(6))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(13))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 1);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Mist,
-        ],
+        conditions: vec![WeatherCondition::Mist,],
     }));
     assert_eq!(r.temperature, Known(19));
     assert_eq!(r.dewpoint, Known(13));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 3000.0, unit: InchesMercury }));
-    assert_eq!(r.remarks, Some("RMK AO2 SLP158 T01890133 $"));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 3000.0,
+            unit: InchesMercury
+        })
+    );
+    assert_eq!(r.remarks, Some("AO2 SLP158 T01890133 $"));
 }
 
 #[test]
@@ -399,19 +591,41 @@ fn test_metar_12() {
     assert_eq!(r.time.hour, 19);
     assert_eq!(r.time.minute, 20);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(140)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 7, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 7,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 9999.0, unit: Metres }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 9999.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 2);
-    assert!(r.cloud_layers.contains(&CloudLayer::Scattered(CloudType::Unknown, Some(35))));
-    assert!(r.cloud_layers.contains(&CloudLayer::Unknown(CloudType::Cumulonimbus, None)));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Scattered(CloudType::Unknown, Some(35))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Unknown(CloudType::Cumulonimbus, None)));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 0);
     assert_eq!(r.temperature, Known(7));
     assert_eq!(r.dewpoint, Known(6));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 997.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 997.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -429,26 +643,48 @@ fn test_metar_13() {
     assert_eq!(r.time.hour, 17);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(310)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 6, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 6,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, Some((280, 360)));
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 7000.0, unit: Metres }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 7000.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 3);
-    assert!(r.cloud_layers.contains(&CloudLayer::Broken(CloudType::Normal, Some(7))));
-    assert!(r.cloud_layers.contains(&CloudLayer::Broken(CloudType::Normal, Some(12))));
-    assert!(r.cloud_layers.contains(&CloudLayer::Broken(CloudType::Normal, Some(19))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(7))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(12))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(19))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 1);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Light,
-        conditions: vec![
-            WeatherCondition::Rain,
-        ],
+        conditions: vec![WeatherCondition::Rain,],
     }));
     assert_eq!(r.temperature, Known(6));
     assert_eq!(r.dewpoint, Known(5));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 1009.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1009.0,
+            unit: Hectopascals
+        })
+    );
     assert_eq!(r.remarks, None);
 }
 
@@ -466,24 +702,40 @@ fn test_metar_14() {
     assert_eq!(r.time.hour, 13);
     assert_eq!(r.time.minute, 35);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(100)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 8, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 8,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 0.25, unit: StatuteMiles }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 0.25,
+            unit: StatuteMiles
+        })
+    );
     assert_eq!(r.clouds, Unknown);
     assert_eq!(r.cloud_layers.len(), 0);
     assert_eq!(r.vert_visibility, Some(VertVisibility::Distance(1)));
     assert_eq!(r.weather.len(), 1);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Fog,
-        ],
+        conditions: vec![WeatherCondition::Fog,],
     }));
     assert_eq!(r.temperature, Known(16));
     assert_eq!(r.dewpoint, Known(15));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 2999.0, unit: InchesMercury }));
-    assert_eq!(r.remarks, Some("RMK AO2 VIS 1/8V1/2 T01610150"));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 2999.0,
+            unit: InchesMercury
+        })
+    );
+    assert_eq!(r.remarks, Some("AO2 VIS 1/8V1/2 T01610150"));
 }
 
 #[test]
@@ -500,25 +752,43 @@ fn test_metar_15() {
     assert_eq!(r.time.hour, 17);
     assert_eq!(r.time.minute, 53);
     assert_eq!(r.wind.dir, Known(WindDirection::Variable));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 4, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 4,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 5.0, unit: StatuteMiles }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 5.0,
+            unit: StatuteMiles
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 1);
-    assert!(r.cloud_layers.contains(&CloudLayer::Few(CloudType::Normal, Some(9))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Few(CloudType::Normal, Some(9))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 1);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Haze,
-        ],
+        conditions: vec![WeatherCondition::Haze,],
     }));
     assert_eq!(r.temperature, Known(19));
     assert_eq!(r.dewpoint, Known(14));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 3002.0, unit: InchesMercury }));
-    assert_eq!(r.remarks, Some("RMK AO2 SLP165 T01940139 10194 20156 51006"));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 3002.0,
+            unit: InchesMercury
+        })
+    );
+    assert_eq!(r.remarks, Some("AO2 SLP165 T01940139 10194 20156 51006"));
 }
 
 #[test]
@@ -535,37 +805,56 @@ fn test_metar_16() {
     assert_eq!(r.time.hour, 18);
     assert_eq!(r.time.minute, 28);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(020)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 4, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 4,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 2.5, unit: StatuteMiles }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 2.5,
+            unit: StatuteMiles
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 2);
-    assert!(r.cloud_layers.contains(&CloudLayer::Broken(CloudType::Normal, Some(7))));
-    assert!(r.cloud_layers.contains(&CloudLayer::Overcast(CloudType::Normal, Some(13))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(7))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Overcast(CloudType::Normal, Some(13))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 2);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Light,
-        conditions: vec![
-            WeatherCondition::Rain,
-        ],
+        conditions: vec![WeatherCondition::Rain,],
     }));
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Mist,
-        ],
+        conditions: vec![WeatherCondition::Mist,],
     }));
     assert_eq!(r.temperature, Known(14));
     assert_eq!(r.dewpoint, Known(12));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 2996.0, unit: InchesMercury }));
-    assert_eq!(r.remarks, Some("RMK AO2 VIS 1 1/2V3 P0002 T01390122 $"));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 2996.0,
+            unit: InchesMercury
+        })
+    );
+    assert_eq!(r.remarks, Some("AO2 VIS 1 1/2V3 P0002 T01390122 $"));
 }
 
 #[test]
 fn test_metar_17() {
-    let metar = "ESSA 081950Z 22021KT 9999 OVC025 06/03 Q0973 R01L/29//95 R08/29//95 R01R/29//95 NOSIG";
+    let metar =
+        "ESSA 081950Z 22021KT 9999 OVC025 06/03 Q0973 R01L/29//95 R08/29//95 R01R/29//95 NOSIG";
     let r = Metar::parse(metar).unwrap_or_else(|e| {
         eprintln!("{}", e);
         assert!(false);
@@ -577,18 +866,38 @@ fn test_metar_17() {
     assert_eq!(r.time.hour, 19);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(220)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 21, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 21,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 9999.0, unit: Metres }));
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 9999.0,
+            unit: Metres
+        })
+    );
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
     assert_eq!(r.cloud_layers.len(), 1);
-    assert!(r.cloud_layers.contains(&CloudLayer::Overcast(CloudType::Normal, Some(25))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Overcast(CloudType::Normal, Some(25))));
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 0);
     assert_eq!(r.temperature, Known(6));
     assert_eq!(r.dewpoint, Known(3));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 973.0, unit: Hectopascals }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 973.0,
+            unit: Hectopascals
+        })
+    );
 }
 
 #[test]
@@ -605,17 +914,41 @@ fn test_metar_18() {
     assert_eq!(r.time.hour, 01);
     assert_eq!(r.time.minute, 55);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(280)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 15, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 15,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
-    assert_eq!(r.wind.gusting, Some(WindSpeed { speed: 21, unit: Knot }));
-    assert_eq!(r.visibility, Known(Visibility { visibility: 10.0, unit: StatuteMiles }));
+    assert_eq!(
+        r.wind.gusting,
+        Some(WindSpeed {
+            speed: 21,
+            unit: Knot
+        })
+    );
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 10.0,
+            unit: StatuteMiles
+        })
+    );
     assert_eq!(r.clouds, Unknown);
     assert_eq!(r.cloud_layers.len(), 0);
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 0);
     assert_eq!(r.temperature, Known(3));
     assert_eq!(r.dewpoint, Known(0));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 2971.0, unit: InchesMercury }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 2971.0,
+            unit: InchesMercury
+        })
+    );
 }
 
 #[test]
@@ -632,32 +965,52 @@ fn test_metar_19() {
     assert_eq!(r.time.hour, 01);
     assert_eq!(r.time.minute, 50);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(110)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 30, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 30,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
-    assert_eq!(r.wind.gusting, Some(WindSpeed { speed: 43, unit: Knot }));
-    assert_eq!(r.visibility, Known(Visibility { visibility: 0.0, unit: StatuteMiles }));
+    assert_eq!(
+        r.wind.gusting,
+        Some(WindSpeed {
+            speed: 43,
+            unit: Knot
+        })
+    );
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 0.0,
+            unit: StatuteMiles
+        })
+    );
     assert_eq!(r.clouds, Unknown);
     assert_eq!(r.cloud_layers.len(), 0);
     assert_eq!(r.vert_visibility, Some(VertVisibility::Distance(5)));
     assert_eq!(r.weather.len(), 2);
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Heavy,
-        conditions: vec![
-            WeatherCondition::Snow,
-        ],
+        conditions: vec![WeatherCondition::Snow,],
     }));
     assert!(r.weather.contains(&Weather {
         intensity: WeatherIntensity::Moderate,
-        conditions: vec![
-            WeatherCondition::Fog,
-        ],
+        conditions: vec![WeatherCondition::Fog,],
     }));
     assert_eq!(r.temperature, Known(-4));
     assert_eq!(r.dewpoint, Known(-4));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 2863.0, unit: InchesMercury }));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 2863.0,
+            unit: InchesMercury
+        })
+    );
 }
 
-/* #[test]
+#[test]
 fn test_metar_20() {
     let metar = "CWPF 220145Z AUTO 25008KT 02/01 RMK AO1 SLP034 T00240009 51016";
     let r = Metar::parse(metar).unwrap_or_else(|e| {
@@ -671,16 +1024,48 @@ fn test_metar_20() {
     assert_eq!(r.time.hour, 01);
     assert_eq!(r.time.minute, 45);
     assert_eq!(r.wind.dir, Known(WindDirection::Heading(250)));
-    assert_eq!(r.wind.speed, Known(WindSpeed { speed: 08, unit: Knot }));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 08,
+            unit: Knot
+        })
+    );
     assert_eq!(r.wind.varying, None);
     assert_eq!(r.wind.gusting, None);
-    assert_eq!(r.visibility, Known(Visibility { visibility: 6000.0, unit: Metres }));
+    assert_eq!(r.visibility, Unknown);
     assert_eq!(r.clouds, Unknown);
     assert_eq!(r.cloud_layers.len(), 0);
     assert_eq!(r.vert_visibility, None);
     assert_eq!(r.weather.len(), 0);
     assert_eq!(r.temperature, Known(2));
     assert_eq!(r.dewpoint, Known(1));
-    assert_eq!(r.pressure, Known(Pressure { pressure: 2971.0, unit: InchesMercury }));
+    assert_eq!(r.pressure, Unknown);
 }
-*/
+
+#[test]
+fn test_metar_21() {
+    let metar = "CWND 220218Z M01/M01 RMK T10091009";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+    println!("{:#?}", r);
+    assert_eq!(r.station, "CWND");
+    assert_eq!(r.time.date, 22);
+    assert_eq!(r.time.hour, 02);
+    assert_eq!(r.time.minute, 18);
+    assert_eq!(r.wind.dir, Unknown);
+    assert_eq!(r.wind.speed, Unknown);
+    assert_eq!(r.wind.varying, None);
+    assert_eq!(r.wind.gusting, None);
+    assert_eq!(r.visibility, Unknown);
+    assert_eq!(r.clouds, Unknown);
+    assert_eq!(r.cloud_layers.len(), 0);
+    assert_eq!(r.vert_visibility, None);
+    assert_eq!(r.weather.len(), 0);
+    assert_eq!(r.temperature, Known(-1));
+    assert_eq!(r.dewpoint, Known(-1));
+    assert_eq!(r.pressure, Unknown);
+}

--- a/tests/metars.rs
+++ b/tests/metars.rs
@@ -1157,3 +1157,61 @@ fn test_metar_24() {
     assert_eq!(r.time.hour, 18);
     assert_eq!(r.time.minute, 52);
 }
+
+#[test]
+fn test_metar_25() {
+    let metar = "VASD 021100Z 09007KT 5000 HZ NSC 27/M2 Q1017 NOSIG";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+    println!("{:#?}", r);
+    assert_eq!(r.station, "VASD");
+    assert_eq!(r.time.date, 02);
+    assert_eq!(r.time.hour, 11);
+    assert_eq!(r.time.minute, 00);
+    assert_eq!(r.wind.dir, Known(WindDirection::Heading(090)));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 07,
+            unit: Knot
+        })
+    );
+    assert_eq!(r.wind.varying, None);
+    assert_eq!(r.wind.gusting, None);
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 5000.0,
+            unit: Metres
+        })
+    );
+}
+
+#[test]
+fn test_metar_26() {
+    let metar = "VASD 021100Z 09007KT 10+SM HZ NSC 27/M2 Q1017 NOSIG";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+    println!("{:#?}", r);
+    assert_eq!(r.station, "VASD");
+    assert_eq!(r.time.date, 02);
+    assert_eq!(r.time.hour, 11);
+    assert_eq!(r.time.minute, 00);
+    assert_eq!(r.wind.dir, Known(WindDirection::Heading(090)));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 07,
+            unit: Knot
+        })
+    );
+    assert_eq!(r.wind.varying, None);
+    assert_eq!(r.wind.gusting, None);
+    assert_eq!(r.visibility, Unknown);
+}

--- a/tests/metars.rs
+++ b/tests/metars.rs
@@ -1076,3 +1076,54 @@ fn test_metar_21() {
     assert_eq!(r.dewpoint, Known(-1));
     assert_eq!(r.pressure, Unknown);
 }
+
+#[test]
+fn test_metar_22() {
+    let metar = "HRYR 031000Z VRB03KT 9999 BKN023 BKN100 23/16 Q1022 NOSIG";
+    let r = Metar::parse(metar).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        assert!(false);
+        std::process::exit(1);
+    });
+    println!("{:#?}", r);
+    assert_eq!(r.station, "HRYR");
+    assert_eq!(r.time.date, 03);
+    assert_eq!(r.time.hour, 10);
+    assert_eq!(r.time.minute, 00);
+    assert_eq!(r.wind.dir, Known(WindDirection::Variable));
+    assert_eq!(
+        r.wind.speed,
+        Known(WindSpeed {
+            speed: 3,
+            unit: Knot
+        })
+    );
+    assert_eq!(r.wind.varying, None);
+    assert_eq!(r.wind.gusting, None);
+    assert_eq!(
+        r.visibility,
+        Known(Visibility {
+            visibility: 9999.0,
+            unit: Metres
+        })
+    );
+    assert_eq!(r.clouds, Known(Clouds::CloudLayers));
+    assert_eq!(r.cloud_layers.len(), 2);
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(23))));
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Broken(CloudType::Normal, Some(100))));
+    assert_eq!(r.vert_visibility, None);
+    assert_eq!(r.weather.len(), 0);
+    assert_eq!(r.temperature, Known(23));
+    assert_eq!(r.dewpoint, Known(16));
+    assert_eq!(
+        r.pressure,
+        Known(Pressure {
+            pressure: 1022.0,
+            unit: Hectopascals
+        })
+    );
+}

--- a/tests/metars.rs
+++ b/tests/metars.rs
@@ -57,7 +57,6 @@ fn test_metar_1() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -97,7 +96,6 @@ fn test_metar_2() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -154,7 +152,6 @@ fn test_metar_3() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -211,7 +208,6 @@ fn test_metar_4() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -251,7 +247,6 @@ fn test_metar_5() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -307,7 +302,6 @@ fn test_metar_6() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -369,7 +363,6 @@ fn test_metar_7() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -419,7 +412,6 @@ fn test_metar_8() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -472,7 +464,6 @@ fn test_metar_9() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -518,7 +509,13 @@ fn test_metar_10() {
             unit: InchesMercury
         })
     );
-    assert_eq!(r.remarks, Some("AO2 SLP264 T00611028 $"));
+    assert_eq!(
+        r.sea_level_pressure,
+        Known(Pressure {
+            pressure: 1026.4,
+            unit: Hectopascals
+        })
+    );
 }
 
 #[test]
@@ -574,7 +571,13 @@ fn test_metar_11() {
             unit: InchesMercury
         })
     );
-    assert_eq!(r.remarks, Some("AO2 SLP158 T01890133 $"));
+    assert_eq!(
+        r.sea_level_pressure,
+        Known(Pressure {
+            pressure: 1015.8,
+            unit: Hectopascals
+        })
+    );
 }
 
 #[test]
@@ -626,7 +629,6 @@ fn test_metar_12() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -685,7 +687,6 @@ fn test_metar_13() {
             unit: Hectopascals
         })
     );
-    assert_eq!(r.remarks, None);
 }
 
 #[test]
@@ -735,7 +736,7 @@ fn test_metar_14() {
             unit: InchesMercury
         })
     );
-    assert_eq!(r.remarks, Some("AO2 VIS 1/8V1/2 T01610150"));
+    assert_eq!(r.sea_level_pressure, Unknown);
 }
 
 #[test]
@@ -788,7 +789,13 @@ fn test_metar_15() {
             unit: InchesMercury
         })
     );
-    assert_eq!(r.remarks, Some("AO2 SLP165 T01940139 10194 20156 51006"));
+    assert_eq!(
+        r.sea_level_pressure,
+        Known(Pressure {
+            pressure: 1016.5,
+            unit: Hectopascals
+        })
+    );
 }
 
 #[test]
@@ -848,7 +855,7 @@ fn test_metar_16() {
             unit: InchesMercury
         })
     );
-    assert_eq!(r.remarks, Some("AO2 VIS 1 1/2V3 P0002 T01390122 $"));
+    assert_eq!(r.sea_level_pressure, Unknown);
 }
 
 #[test]

--- a/tests/special_cases.rs
+++ b/tests/special_cases.rs
@@ -1,4 +1,4 @@
-use metar::{*, Data::*};
+use metar::{Data::*, *};
 
 #[test]
 fn test_all_blank() {
@@ -25,57 +25,12 @@ fn test_all_blank() {
 
     assert_eq!(r.visibility, Unknown);
     assert_eq!(r.clouds, Known(Clouds::CloudLayers));
-    assert_eq!(r.cloud_layers.len(), 1);
-    assert!(r.cloud_layers.contains(&CloudLayer::Unknown(CloudType::Unknown, None)));
+    assert_eq!(r.cloud_layers.len(), 2);
+    assert!(r
+        .cloud_layers
+        .contains(&CloudLayer::Unknown(CloudType::Unknown, None)));
 
     assert_eq!(r.temperature, Unknown);
     assert_eq!(r.dewpoint, Unknown);
     assert_eq!(r.pressure, Unknown);
-}
-
-#[test]
-fn test_doesnt_panic_with_bad_pressure() {
-    let metar = "EGHI 282120Z 19015KT 140V220 6000 RA SCT006 BKN009 16/14 1006";
-    // Test fails automatically if this panics
-    let r = Metar::parse(metar);
-    assert!(r.is_err());
-    
-    let metar = "EGHI 282120Z 19015KT 140V220 6000 RA SCT006 BKN009 16/14 Q10";
-    // Test fails automatically if this panics
-    let r = Metar::parse(metar);
-    assert!(r.is_err());
-}
-
-#[test]
-fn test_doesnt_panic_with_bad_temps() {
-    let metar = "EGPC 211650Z 33026G37KT 9999 FEW021 12/7 Q1026";
-    // Test fails automatically if this panics
-    let r = Metar::parse(metar);
-    assert!(r.is_err());
-    
-    let metar = "EGPC 211650Z 33026G37KT 9999 FEW021 1/70 Q1026";
-    // Test fails automatically if this panics
-    let r = Metar::parse(metar);
-    assert!(r.is_err());
-}
-
-#[test]
-fn test_doesnt_panic_with_bad_visibility() {
-    let metar = "EGPC 211650Z 33026G37KT 1 FEW021 12/7 Q1026";
-    // Test fails automatically if this panics
-    let r = Metar::parse(metar);
-    assert!(r.is_err());
-    
-    let metar = "EGPC 211650Z 33026G37KT 100SM FEW021 1/70 Q1026";
-    // Test fails automatically if this panics
-    let r = Metar::parse(metar);
-    assert!(r.is_err());
-}
-
-#[test]
-fn test_doesnt_panic_with_bad_wind() {
-    let metar = "EGPC 211650Z 3026KT 9999 FEW021 12/7 Q1026";
-    // Test fails automatically if this panics
-    let r = Metar::parse(metar);
-    assert!(r.is_err());
 }


### PR DESCRIPTION
This library is great. I am using it to parse the global list of METARs available from the US NWS at [http://tgftp.nws.noaa.gov/data/observations/metar/cycles/01Z.txt](http://tgftp.nws.noaa.gov/data/observations/metar/cycles/01Z.txt) (change hour to any between 00-23 to grab a full days worth of data).

There were a few changes that needed to be made to get everything to parse correctly, and then a feature I needed.

- Allow for numbers in station names
- Changed the state machine so it checks if anything between the observation date and remarks is weather/clouds/vis/pressure. This supports the weird cases where they aren't all included as seen in the added tests. The downside of this change is that you can no longer "validate" a METAR as being improperly formatted easily since we ignore the parsing errors assuming it must always be a different group type
- Removed the remarks string and started to parse it. Specifically parsing our the sea level pressure right now. 
- Added support for RE (recent) as a weather modifier like light & heavy. 
- Support visibility being less than 1/4th SM by just setting it to 0 for now.

I ran `cargo fmt` on this so some changes are just formatting...

Feel free to merge this or cherry pick anything you'd like. I just wanted to contribute it back since I benefited from using this as a great starting point!